### PR TITLE
Crash with io:format in on_load call with OTP-26

### DIFF
--- a/src/phonenumber_util.erl
+++ b/src/phonenumber_util.erl
@@ -59,7 +59,6 @@
 
 load_nif() ->
     SoName = elibphone_utils:get_priv_path(<<(atom_to_binary(?MODULE, latin1))/binary, "_nif">>),
-    io:format("Loading library: ~p ~n", [SoName]),
     ok = erlang:load_nif(SoName, 0).
 
 not_loaded(Line) ->


### PR DESCRIPTION
When using OTP-26 our application crashes when io:format is used in the on_load function.

There is an open issue in otp repo with a similar issue where it's mentioned that on_load is somewhat brittle. https://github.com/erlang/otp/issues/7466#issuecomment-1623247934

```
=INFO REPORT==== 10-Aug-2023::11:01:37.449084 ===
init got unexpected: {io_request,<0.1805.0>,
                         #Ref<0.3063375415.1090256898.200776>,
                         {put_chars,unicode,io_lib,format,
                             ["Loading library: ~p ~n",
                              [<<"/opt/smd/_build/local/rel/smd/lib/elibphonenumber-8.13.17/priv/phonenumber_util_nif">>]]}}

```